### PR TITLE
Allow to use with Rails 5 and return 404 status code if object does not exist

### DIFF
--- a/app/controllers/postgresql_lo_streamer/lo_controller.rb
+++ b/app/controllers/postgresql_lo_streamer/lo_controller.rb
@@ -23,6 +23,12 @@ module PostgresqlLoStreamer
       end
     end
 
+    def connection
+      @con ||= ActiveRecord::Base.connection.raw_connection
+    end
+
+    private
+      
     def object_exists?(identifier)
       begin
         connection.lo_open(identifier, ::PG::INV_READ)
@@ -30,17 +36,13 @@ module PostgresqlLoStreamer
         if e.to_s.include? "does not exist"
           return false
         end
+          
+        raise
       end
 
       return true
     end
-
-    def connection
-      @con ||= ActiveRecord::Base.connection.raw_connection
-    end
-
-    private
-
+      
     def configuration
       PostgresqlLoStreamer.configuration
     end

--- a/app/controllers/postgresql_lo_streamer/lo_controller.rb
+++ b/app/controllers/postgresql_lo_streamer/lo_controller.rb
@@ -4,16 +4,35 @@ module PostgresqlLoStreamer
   class LoController < ActionController::Base
     def stream
       send_file_headers! configuration.options
+
+      object_identifier = params[:id].to_i
+      if !object_exists?(object_identifier)
+        self.status = 404
+        render :nothing => true and return
+      end
+
       self.status = 200
       self.response_body = Enumerator.new do |y|
         connection.transaction do
-          lo = connection.lo_open(params[:id].to_i, ::PG::INV_READ)
+          lo = connection.lo_open(object_identifier, ::PG::INV_READ)
           while data = connection.lo_read(lo, 4096) do
             y << data
           end
           connection.lo_close(lo)
         end
       end
+    end
+
+    def object_exists?(identifier)
+      begin
+        connection.lo_open(identifier, ::PG::INV_READ)
+      rescue PG::Error => e
+        if e.to_s.include? "does not exist"
+          return false
+        end
+      end
+
+      return true
     end
 
     def connection

--- a/postgresql_lo_streamer.gemspec
+++ b/postgresql_lo_streamer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 4.0"
+  s.add_dependency "rails", "~> 5.0"
 
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rspec-its"

--- a/postgresql_lo_streamer.gemspec
+++ b/postgresql_lo_streamer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 5.0"
+  s.add_dependency "rails", ">= 4.0"
 
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rspec-its"

--- a/spec/controllers/postgresql_lo_streamer/lo_controller_spec.rb
+++ b/spec/controllers/postgresql_lo_streamer/lo_controller_spec.rb
@@ -3,19 +3,19 @@ require 'rails_helper'
 describe PostgresqlLoStreamer::LoController do
   routes { PostgresqlLoStreamer::Engine.routes }
 
-  subject{ response }
-  let(:connection){ ActiveRecord::Base.connection.raw_connection }
-  let(:file_content){ File.open("#{ENGINE_RAILS_ROOT}/spec/fixtures/test.jpg").read }
+  subject { response }
+  let(:connection) { ActiveRecord::Base.connection.raw_connection }
+  let(:file_content) { File.open("#{ENGINE_RAILS_ROOT}/spec/fixtures/test.jpg").read }
 
 
   describe "#connection" do
-    subject{ PostgresqlLoStreamer::LoController.new.connection }
-    it{ should == ActiveRecord::Base.connection.raw_connection }
+    subject { PostgresqlLoStreamer::LoController.new.connection }
+    it { should == ActiveRecord::Base.connection.raw_connection }
   end
 
   describe "GET stream" do
     before do
-      expect(controller).to receive(:send_file_headers!).with({:type=>"image/png", :disposition=>"inline"})
+      expect(controller).to receive(:send_file_headers!).with({:type => "image/png", :disposition => "inline"})
       connection.transaction do
         @oid = connection.lo_creat
         lo = connection.lo_open(@oid, ::PG::INV_WRITE)
@@ -29,7 +29,17 @@ describe PostgresqlLoStreamer::LoController do
       connection.lo_unlink(@oid)
     end
 
-    its(:body){ should == file_content }
-    its(:status){ should == 200 }
+    its(:body) { should == file_content }
+    its(:status) { should == 200 }
+  end
+
+  describe "GET non-existing stream" do
+    before do
+      expect(controller).to receive(:send_file_headers!).with({:type => "image/png", :disposition => "inline"})
+      get :stream, :id => 9999
+    end
+
+    its(:body) { should == nil }
+    its(:status) { should == 404 }
   end
 end


### PR DESCRIPTION
Hi,

Thanks for publishing this. I could not install this Gem when using with a Rails 5 app. Only the gemspec needed a change, the rest of the Gem works fine on Rails 5.

In addition, if an object does not exist a 500 status code would be returned. I modified it a bit and now it properly returns a 404 status code if the object does not exist.

I see the test fails but it's unrelated to the changes. Also, I am unfamiliar with rspec so I haven't tested the test that I added but it's probably good to go.
