### PR TITLE
Handle Mime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,31 @@ You can adjust default file streaming headers by tweaking configuration options:
       config.options = {:type => 'image/png', :disposition => 'inline'}
     end
 
-
 Add to your `config/routes.rb` the mount url where you are going to retrieve the files.
 The following example will create a route `/image_file/:id` where :id is the oid of the Large Object in the database:
 
     mount PostgresqlLoStreamer::Engine => "/image_file"
+
+## Passing mime-type with url
+
+If you specify an extension with your url, the default file streaming headers will be overridden.
+
+```ruby
+/file/38681 #=> image/png
+/file/38681.jpg #=> image/jpeg
+/file/38681.css #=> text/css
+```
+
+This allows you to dynamically stream resources of different types and send appropriate headers. Please note that only the following types will be sent with an inline disposition, otherwise, it will be sent as an attachment, forcing a download.
+
+  image/jpeg
+  image/png
+  image/gif
+  image/svg+xml
+  text/css
+  text/plain
+
+In order for this to work in practice, you will likely need to store the extension or the url in the database alongside the oid when saving the file.
 
 ## Using it with carrierwave-postgresql
 
@@ -31,7 +51,7 @@ If you are storing your files in the database using the [carrierwave-postgresql]
 So, for our previous example, if you have a model called `Image`, with and attribute called `file` (which is the oid referencing the Large Object), then the model will generate the URL matching our example. If you have more than one large object attribute in your database you can mount this engine multiple times with different URLs.
 
 ## Contributing to postgresql_lo_streamer
- 
+
  * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.
  * Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it.
  * Fork the project.

--- a/README.md
+++ b/README.md
@@ -27,20 +27,18 @@ The following example will create a route `/image_file/:id` where :id is the oid
 
 If you specify an extension with your url, the default file streaming headers will be overridden.
 
-```ruby
-/file/38681 #=> image/png
-/file/38681.jpg #=> image/jpeg
-/file/38681.css #=> text/css
-```
+    /file/38681 #=> image/png
+    /file/38681.jpg #=> image/jpeg
+    /file/38681.css #=> text/css
 
 This allows you to dynamically stream resources of different types and send appropriate headers. Please note that only the following types will be sent with an inline disposition, otherwise, it will be sent as an attachment, forcing a download.
 
-  image/jpeg
-  image/png
-  image/gif
-  image/svg+xml
-  text/css
-  text/plain
+    image/jpeg
+    image/png
+    image/gif
+    image/svg+xml
+    text/css
+    text/plain
 
 In order for this to work in practice, you will likely need to store the extension or the url in the database alongside the oid when saving the file.
 

--- a/app/controllers/postgresql_lo_streamer/lo_controller.rb
+++ b/app/controllers/postgresql_lo_streamer/lo_controller.rb
@@ -59,7 +59,6 @@ module PostgresqlLoStreamer
     end
 
     def disposition_from_type(type)
-      #subjective switch statement, should be able to configure eventually
       inline_types = [
         "image/jpeg",
         "image/png",
@@ -68,17 +67,11 @@ module PostgresqlLoStreamer
         "text/css",
         "text/plain"
       ]
-      attachment_types = [
-        "text/csv"
-      ]
-
       case type
       when *inline_types
         "inline"
-      when *attachment_types
-        "attachment"
       else
-        "attachment" #fallback, subjective
+        "attachment" #fallback
       end
     end
 

--- a/app/controllers/postgresql_lo_streamer/lo_controller.rb
+++ b/app/controllers/postgresql_lo_streamer/lo_controller.rb
@@ -66,7 +66,7 @@ module PostgresqlLoStreamer
         "image/gif",
         "image/svg+xml",
         "text/css",
-        "text/plain",
+        "text/plain"
       ]
       attachment_types = [
         "text/csv"

--- a/spec/controllers/postgresql_lo_streamer/lo_controller_spec.rb
+++ b/spec/controllers/postgresql_lo_streamer/lo_controller_spec.rb
@@ -33,6 +33,26 @@ describe PostgresqlLoStreamer::LoController do
     its(:status) { should == 200 }
   end
 
+  describe "GET mime stream" do
+    before do
+      expect(controller).to receive(:send_file_headers!).with({:type => "image/jpg", :disposition => "inline"})
+      connection.transaction do
+        @oid = connection.lo_creat
+        lo = connection.lo_open(@oid, ::PG::INV_WRITE)
+        size = connection.lo_write(lo, file_content)
+        connection.lo_close(lo)
+      end
+      get :stream, :id => @oid, :format => "jpg"
+    end
+
+    after do
+      connection.lo_unlink(@oid)
+    end
+
+    its(:body) { should == file_content }
+    its(:status) { should == 200 }
+  end
+
   describe "GET non-existing stream" do
     before do
       expect(controller).to receive(:send_file_headers!).with({:type => "image/png", :disposition => "inline"})

--- a/spec/controllers/postgresql_lo_streamer/lo_controller_spec.rb
+++ b/spec/controllers/postgresql_lo_streamer/lo_controller_spec.rb
@@ -6,6 +6,7 @@ describe PostgresqlLoStreamer::LoController do
   subject { response }
   let(:connection) { ActiveRecord::Base.connection.raw_connection }
   let(:file_content) { File.open("#{ENGINE_RAILS_ROOT}/spec/fixtures/test.jpg").read }
+  let(:csv_file_content) { File.open("#{ENGINE_RAILS_ROOT}/spec/fixtures/test.csv").read }
 
 
   describe "#connection" do
@@ -33,16 +34,16 @@ describe PostgresqlLoStreamer::LoController do
     its(:status) { should == 200 }
   end
 
-  describe "GET mime stream" do
+  describe "GET mime stream jpg" do
     before do
-      expect(controller).to receive(:send_file_headers!).with({:type => "image/jpg", :disposition => "inline"})
+      expect(controller).to receive(:send_file_headers!).with({:type => "image/jpeg", :disposition => "inline"})
       connection.transaction do
         @oid = connection.lo_creat
         lo = connection.lo_open(@oid, ::PG::INV_WRITE)
         size = connection.lo_write(lo, file_content)
         connection.lo_close(lo)
       end
-      get :stream, :id => @oid, :format => "jpg"
+      get :stream, :id => @oid, format: 'jpg'
     end
 
     after do
@@ -50,6 +51,26 @@ describe PostgresqlLoStreamer::LoController do
     end
 
     its(:body) { should == file_content }
+    its(:status) { should == 200 }
+  end
+
+  describe "GET mime stream csv" do
+    before do
+      expect(controller).to receive(:send_file_headers!).with({:type => "text/csv", :disposition => "attachment"})
+      connection.transaction do
+        @oid = connection.lo_creat
+        lo = connection.lo_open(@oid, ::PG::INV_WRITE)
+        size = connection.lo_write(lo, csv_file_content)
+        connection.lo_close(lo)
+      end
+      get :stream, :id => @oid, format: 'csv'
+    end
+
+    after do
+      connection.lo_unlink(@oid)
+    end
+
+    its(:body) { should == csv_file_content }
     its(:status) { should == 200 }
   end
 

--- a/spec/fixtures/test.csv
+++ b/spec/fixtures/test.csv
@@ -1,0 +1,2 @@
+header_1, header_2
+dummy_1, dummy_2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,12 +21,12 @@ rescue
   ActiveRecord::Base.establish_connection(
     adapter: "postgresql",
     host: "localhost",
-    username: "ryanhelsing",
-    password: "",
+    username: "postgres",
+    password: "postgres",
     port: 5432,
     database: "postgres"
   )
-  # ActiveRecord::Base.connection.execute "CREATE DATABASE postgresql_lo_test"
+  ActiveRecord::Base.connection.execute "CREATE DATABASE postgresql_lo_test"
   retry
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,12 +21,12 @@ rescue
   ActiveRecord::Base.establish_connection(
     adapter: "postgresql",
     host: "localhost",
-    username: "postgres",
-    password: "postgres",
+    username: "ryanhelsing",
+    password: "",
     port: 5432,
     database: "postgres"
   )
-  ActiveRecord::Base.connection.execute "CREATE DATABASE postgresql_lo_test"
+  # ActiveRecord::Base.connection.execute "CREATE DATABASE postgresql_lo_test"
   retry
 end
 


### PR DESCRIPTION
Okay, this should be good to go.. does not depend on mimemagic (uses built in rails library instead, but less types are supported.. like docx). Eventually we should add the ability to configure the disposition based on the type. Let me know if you can think of other types that should be inline, I'm sure there are many. #9 

The usage is dependent on sending an extension w/ your url, which will be placed into params[:format] by default. I check if the format is present and if not, it will fallback to current behavior.